### PR TITLE
Fix showing the active branch after a checkout from Merginal window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/autoload/merginal.vim
+++ b/autoload/merginal.vim
@@ -489,7 +489,7 @@ function! s:checkoutBranchUnderCursor()
         if !v:shell_error
             call merginal#reloadBuffers()
         endif
-        call merginal#tryRefreshBranchListBuffer(0)
+        call merginal#tryRefreshBranchListBuffer(1)
     endif
 endfunction
 


### PR DESCRIPTION
After a `C` command, for example, the merginal branch list window is not updated with the current branch details. This commit fixes this and also adds a gitignore spec for `doc/tags` file.