### PR TITLE
Fix Language environment error in neovim, try catch block to has_key

### DIFF
--- a/autoload/merginal/modulelib.vim
+++ b/autoload/merginal/modulelib.vim
@@ -10,12 +10,10 @@ function! merginal#modulelib#makeModule(namespace, name, parent)
 endfunction
 
 function! s:populate(object, moduleName)
-    try
-        let l:module = s:modules[a:moduleName]
-    catch /E716/
-        execute 'runtime autoload/merginal/buffers/'.a:moduleName.'.vim'
-        let l:module = s:modules[a:moduleName]
-    endtry
+    if !has_key(s:modules, a:moduleName)
+      execute 'runtime autoload/merginal/buffers/'.a:moduleName.'.vim'
+    endif
+    let l:module = s:modules[a:moduleName]
 
     if !empty(l:module.parent)
         call s:populate(a:object, l:module.parent)
@@ -84,4 +82,3 @@ function! s:f.addCommand(functionName, args, command, keymaps, doc) dict abort
     "let self._meta[a:functionName] = l:meta
     call add(self._meta, l:meta)
 endfunction
-


### PR DESCRIPTION
In my default Japanese neovim environment, when I run the Merginal command I get an error.
`$ LANG=ja_JP.UTF-8 nvim`

```
function merginal#openMerginalBuffer[5]..merginal#modulelib#createObject[4]..<SNR>196_populate の処理中にエラーが検出されました:
行    2:
E716: 辞書型にキーが存在しません: branchList
E15: 無効な式です: s:modules[a:moduleName]
function merginal#openMerginalBuffer の処理中にエラーが検出されました:
行    5:
E488: 余分な文字が後ろにあります
```

If LANG is explicitly specified as C, it does not occur.
`$ LANG=C nvim`
If try catch block was changed to has_key, no error occurred even in Japanese neovim environment.