### PR TITLE
Add option to split vertically/horizontally

### DIFF
--- a/autoload/merginal/buffers/base.vim
+++ b/autoload/merginal/buffers/base.vim
@@ -94,7 +94,7 @@ function! s:f.openTuiBuffer(targetWindow) dict abort
         if -1 < a:targetWindow
             enew
         else
-            execute get(g:, 'merginal_windowWidth', 40).'vnew'
+            execute get(g:, 'merginal_windowWidth', 40).get(g:, 'merginal_splitType', 'v').'new'
         endif
         setlocal buftype=nofile
         setlocal bufhidden=wipe

--- a/doc/merginal.txt
+++ b/doc/merginal.txt
@@ -53,3 +53,6 @@ CONFIGURATION                                       *merginal-configuration*
 
 Set *g:merginal_windowWidth* to the width of the window where the Merignal
 buffer is shown.
+
+Set *g:merginal_splitType* to choose if vim-merginal will split vertically (the default)
+or horizontally (set this to '', empty string)


### PR DESCRIPTION
Hi,

this makes it possible to split the window horizontally.

Also, now that this is possible maybe it would be a good idea to rename the option `g:merginal_windowWidth` to `g:merginal_windowSize` since now it is useful both for horizontal e vertical splits.

Let me know what do you think and I will make any adjustments needed.

Thanks,