### PR TITLE
Fix fileFullPath bug

### DIFF
--- a/autoload/merginal/buffers/fileListBase.vim
+++ b/autoload/merginal/buffers/fileListBase.vim
@@ -4,7 +4,7 @@ function! s:f.filePaths(filename) dict abort
     let l:result = {}
     let l:result.name = a:filename " For backwards compatibility
     let l:result.fileInTree = fnamemodify(a:filename, ':.')
-    let l:result.fileFullPath = fnamemodify(self.repo.git_dir, ':h').'/'.a:filename
+    let l:result.fileFullPath = self.repo.tree(a:filename)
     return l:result
 endfunction
 

--- a/autoload/merginal/buffers/fileListBase.vim
+++ b/autoload/merginal/buffers/fileListBase.vim
@@ -4,7 +4,7 @@ function! s:f.filePaths(filename) dict abort
     let l:result = {}
     let l:result.name = a:filename " For backwards compatibility
     let l:result.fileInTree = fnamemodify(a:filename, ':.')
-    let l:result.fileFullPath = fnamemodify(a:filename, ':p')
+    let l:result.fileFullPath = fnamemodify(self.repo.git_dir, ':h').'/'.a:filename
     return l:result
 endfunction
 


### PR DESCRIPTION
Fixed #31 

Depending on the location of the current directory, `fnamemodify` could not get the correct full path.
Using `git_dir`, I got the full path and responded.