### PR TITLE
Merging with --no-ff issue

### DIFF
--- a/autoload/merginal/buffers/branchList.vim
+++ b/autoload/merginal/buffers/branchList.vim
@@ -76,8 +76,7 @@ call s:f.addCommand('deleteBranchUnderCursor', [], 'MerginalDelete', ['dd', 'D']
 
 function! s:f.mergeBranchUnderCursor(...) dict abort
     let l:branch = self.branchDetails('.')
-    let l:gitArgs = ['merge', '--no-commit', l:branch.handle, '--']
-    call extend(l:gitArgs, a:000)
+    let l:gitArgs = ['merge', '--no-commit', a:000, l:branch.handle, '--']
     call call(self.gitEcho, l:gitArgs, self)
     let l:confilctsBuffer = self.gotoSpecialModeBuffer()
     if empty(l:confilctsBuffer)


### PR DESCRIPTION
I've read through the history of commits and on the last version update, this logic has changed and caused issue with merging with --no-ff.

I replicated the old logic :

`a:000` had to be added in `l:gitArgs` _before_ `l:branch.handle, '--'`