### PR TITLE
Auto resize split to strlen of branch name + padding

### DIFF
--- a/autoload/merginal/buffers/base.vim
+++ b/autoload/merginal/buffers/base.vim
@@ -67,7 +67,10 @@ function! s:f.gitRun(...) dict abort
     execute 'cd '.fnameescape(self.fugitiveContext.work_tree)
     try
         let l:gitCommand = self.gitCommand('--no-pager', a:000)
-        echo 'Running command' string(l:gitCommand)
+        let l:show_commands = get(g:, 'merginal_showCommands', 1)
+        if l:show_commands
+            echo 'Running command' string(l:gitCommand)
+        endif
         return merginal#system(l:gitCommand)
     finally
         execute 'cd '.fnameescape(l:dir)

--- a/autoload/merginal/buffers/base.vim
+++ b/autoload/merginal/buffers/base.vim
@@ -251,7 +251,7 @@ function! s:f.refresh() dict abort
                 let l:max_strlen = 0
                 for line in self.body
                     if strlen(line) ># l:max_strlen
-                        let l:max_strlen = strlen(line) + 5
+                        let l:max_strlen = strlen(line) + get(g:, 'merginalResizePadding', 5)
                     endif
                 endfor
                 call win_move_separator(winnr(), (l:max_strlen - l:cur_win.width))

--- a/autoload/merginal/buffers/base.vim
+++ b/autoload/merginal/buffers/base.vim
@@ -244,6 +244,18 @@ function! s:f.refresh() dict abort
             let l:currentLine = l:currentLine + len(self.header)
             setlocal nomodifiable
 
+            " Resize window if desired
+            let l:resize_to_branch_strlen = get(g:, 'merginal_resizeWindowToBranchLen', 0)
+            if l:resize_to_branch_strlen
+                let l:cur_win = getwininfo(win_getid())[0]
+                let l:max_strlen = 0
+                for line in self.body
+                    if strlen(line) ># l:max_strlen
+                        let l:max_strlen = strlen(line) + 5
+                    endif
+                endfor
+                call win_move_separator(winnr(), (l:max_strlen - l:cur_win.width))
+            endif
             execute l:currentLine
             execute 'normal! '.l:currentColumn.'|'
         finally

--- a/autoload/merginal/buffers/base.vim
+++ b/autoload/merginal/buffers/base.vim
@@ -251,7 +251,7 @@ function! s:f.refresh() dict abort
                 let l:max_strlen = 0
                 for line in self.body
                     if strlen(line) ># l:max_strlen
-                        let l:max_strlen = strlen(line) + get(g:, 'merginalResizePadding', 5)
+                        let l:max_strlen = strlen(line) + get(g:, 'merginal_resizePadding', 5)
                     endif
                 endfor
                 call win_move_separator(winnr(), (l:max_strlen - l:cur_win.width))

--- a/doc/merginal.txt
+++ b/doc/merginal.txt
@@ -55,11 +55,18 @@ Set *g:merginal_windowWidth* or *g:merginal_windowSize* to the size of the windo
 where the Merginal buffer will be shown.
 
 Set *g:merginal_splitType* to choose if vim-merginal will split vertically (the default)
-or horizontally (set this to '', empty string)
+or horizontally (set this to '', empty string).
 
 Set *g:merginal_logCommitCount* to limit the number of commits displayed in the Merginal
 buffer. Please note that there is no `See More` feature so there will be no indicator if
-there are unseen commits
+there are unseen commits.
 
 Set *g:merginal_remoteVisible* to choose if vim-merginal will view remote branches (the default)
 or hide (set this to 0).
+
+Set *g:merginal_showCommands* 0 to show hide git command being run (default is
+1).
+
+Set *g:merginal_resizeWindowToBranchLen* to 1 to automatically resize the split
+to the longest branch name length. This overrides g:merginal_windowWidth and
+g:merginal_windowSize. Default is 0.

--- a/doc/merginal.txt
+++ b/doc/merginal.txt
@@ -64,7 +64,7 @@ there are unseen commits.
 Set *g:merginal_remoteVisible* to choose if vim-merginal will view remote branches (the default)
 or hide (set this to 0).
 
-Set *g:merginal_showCommands* 0 to show hide git command being run (default is
+Set *g:merginal_showCommands* 0 to hide git command being run (default is
 1).
 
 Set *g:merginal_resizeWindowToBranchLen* to 1 to automatically resize the split

--- a/doc/merginal.txt
+++ b/doc/merginal.txt
@@ -71,5 +71,5 @@ Set *g:merginal_resizeWindowToBranchLen* to 1 to automatically resize the split
 to the longest branch name length. This overrides g:merginal_windowWidth and
 g:merginal_windowSize. Default is 0.
 
-Set *g:merginalResizePadding* to the number of characters you would like padded to the end 
+Set *g:merginal_resizePadding* to the number of characters you would like padded to the end 
 of the branch name length when using *g:merginal_resizeWindowToBranchLen*. Default 5.

--- a/doc/merginal.txt
+++ b/doc/merginal.txt
@@ -70,3 +70,6 @@ Set *g:merginal_showCommands* 0 to show hide git command being run (default is
 Set *g:merginal_resizeWindowToBranchLen* to 1 to automatically resize the split
 to the longest branch name length. This overrides g:merginal_windowWidth and
 g:merginal_windowSize. Default is 0.
+
+Set *g:merginalResizePadding* to the number of characters you would like padded to the end 
+of the branch name length when using *g:merginal_resizeWindowToBranchLen*. Default 5.


### PR DESCRIPTION
Firstly want to say thanks for the great work on the plugin!

I've:
- Added flag to resize window to length of longest branch name + padding (user definable, default 5 chars). 
- Added ability to hide echo output
- Updated docs accordingly

All changes have left the existing default functionality in place (does not auto resize if user does not define switch, echo commands are done unless user sets switch)
